### PR TITLE
Fix code->html that contains a reader tag

### DIFF
--- a/src/cljs/dynadoc/core.cljs
+++ b/src/cljs/dynadoc/core.cljs
@@ -1,18 +1,22 @@
 (ns dynadoc.core
-  (:require [cljs.tools.reader :refer [read-string]]
-            [rum.core :as rum]
+  (:require [rum.core :as rum]
             [dynadoc.common :as common]
             [paren-soup.core :as ps]
             [eval-soup.core :as es]
             [goog.object :as gobj]
             [clojure.walk :refer [postwalk]]
-            [dynadoc.aliases])
+            [dynadoc.aliases]
+            [oakcljs.tools.reader :as rdr])
   (:import goog.net.XhrIo))
 
 (def version "1.4.10")
 (def ^:const api-url "https://clojars.org/api/artifacts/dynadoc")
 
 (defonce *state (atom {}))
+
+(defn read-string [x]
+  (binding [rdr/*suppress-read* true]
+    (rdr/read-string x)))
 
 (defn with-focus->binding [with-focus]
   (let [{:keys [binding]} with-focus
@@ -79,7 +83,7 @@
 (defn cljs-compiler-fn [example forms cb]
   (es/code->results
     (into [(list 'ns (:ns-sym @*state))]
-      (mapv (partial transform example) forms))
+          (mapv (partial transform example) forms))
     (fn [results]
       (->> results
            rest ; ignore the result of ns


### PR DESCRIPTION
I've hit a problem when trying to render examples that contain reader tags (mainly from Spec-generated data).

This seems to allow it to work with reader tags (assuming oakes/html-soup#1 is the right way)